### PR TITLE
Update project version to 0.1.0 and standardize dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ A framework-agnostic Java library for standardized API error responses aligned w
 - **Java 21+**
 - **Maven 3.6+**
 
+## Compatibility
+
+| response4j | Java | Spring Boot | Quarkus | Micronaut |
+|------------|------|-------------|---------|-----------|
+| 0.1.0      | 21+  | 3.5.x       | 3.32.x  | 4.10.x    |
+
 ## Modules
 
 | Module | Description |

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.iamkavindu</groupId>
     <artifactId>response4j</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
 
     <name>response4j</name>

--- a/response4j-core/pom.xml
+++ b/response4j-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.iamkavindu</groupId>
         <artifactId>response4j</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>response4j-core</artifactId>

--- a/response4j-micronaut/pom.xml
+++ b/response4j-micronaut/pom.xml
@@ -6,11 +6,27 @@
     <parent>
         <groupId>io.github.iamkavindu</groupId>
         <artifactId>response4j</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>response4j-micronaut</artifactId>
     <name>response4j-micronaut</name>
+
+    <properties>
+        <micronaut.version>4.10.8</micronaut.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.micronaut.platform</groupId>
+                <artifactId>micronaut-platform</artifactId>
+                <version>${micronaut.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -21,19 +37,16 @@
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http</artifactId>
-            <version>4.3.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http-server</artifactId>
-            <version>4.3.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-inject</artifactId>
-            <version>4.3.5</version>
             <scope>provided</scope>
         </dependency>
 

--- a/response4j-quarkus/pom.xml
+++ b/response4j-quarkus/pom.xml
@@ -6,11 +6,27 @@
     <parent>
         <groupId>io.github.iamkavindu</groupId>
         <artifactId>response4j</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>response4j-quarkus</artifactId>
     <name>response4j-quarkus</name>
+
+    <properties>
+        <quarkus.version>3.32.1</quarkus.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -21,13 +37,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive</artifactId>
-            <version>3.8.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
-            <version>3.8.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/response4j-spring/pom.xml
+++ b/response4j-spring/pom.xml
@@ -6,11 +6,27 @@
     <parent>
         <groupId>io.github.iamkavindu</groupId>
         <artifactId>response4j</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>response4j-spring</artifactId>
     <name>response4j-spring</name>
+
+    <properties>
+        <spring-boot.version>3.5.9</spring-boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -21,13 +37,11 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>6.1.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>3.2.3</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
- Updated version from `0.1.0-SNAPSHOT` to `0.1.0` in all module POM files.
- Introduced centralized dependency management for Spring Boot (3.5.x), Micronaut (4.10.x), and Quarkus (3.32.x).
- Updated README.md with a compatibility table for supported frameworks and versions.