### PR TITLE
Enhance ProblemDetail for RFC 9457 compliance and multi-error support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![response4j flow](./docs/response4j-flow.svg)
 # response4j
 
-A framework-agnostic Java library for standardized API error responses aligned with [RFC 7807 Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc7807).
+A framework-agnostic Java library for standardized API error responses aligned with [RFC 9457 Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457).
 
 ## Features
 
-- **RFC 7807 compliant** — Error responses follow the Problem Details specification
+- **RFC 9457 compliant** — Error responses follow the Problem Details specification
 - **Immutable records** — Core models use Java Records for thread-safe, immutable data structures
 - **Framework-agnostic core** — Use `response4j-core` with any Java web framework
 - **Spring Boot support** — Optional `response4j-spring` module with auto-configuration
@@ -46,7 +46,7 @@ Add the dependency for your use case.
 <dependency>
     <groupId>io.github.iamkavindu</groupId>
     <artifactId>response4j-core</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -56,7 +56,7 @@ Add the dependency for your use case.
 <dependency>
     <groupId>io.github.iamkavindu</groupId>
     <artifactId>response4j-spring</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -66,7 +66,7 @@ Add the dependency for your use case.
 <dependency>
     <groupId>io.github.iamkavindu</groupId>
     <artifactId>response4j-quarkus</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -76,7 +76,7 @@ Add the dependency for your use case.
 <dependency>
     <groupId>io.github.iamkavindu</groupId>
     <artifactId>response4j-micronaut</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -138,7 +138,7 @@ Example success response:
 
 #### Error responses
 
-Annotate exception classes with `@ProblemResponse` to control how they are mapped to RFC 7807 Problem Details:
+Annotate exception classes with `@ProblemResponse` to control how they are mapped to RFC 9457 Problem Details:
 
 ```java
 @ProblemResponse(status = 404, title = "User Not Found")
@@ -194,7 +194,7 @@ public class UserResource {
 
 ### Micronaut
 
-With `response4j-micronaut` on the classpath, a bean factory auto-registers `ApiResponseMapper` and `ProblemDetailMapper` when Micronaut HTTP is present. `Response4jHttpServerFilter` applies `@SuccessResponse` wrapping to controller responses, and `Response4jExceptionHandler` maps exceptions to RFC 7807 Problem Details.
+With `response4j-micronaut` on the classpath, a bean factory auto-registers `ApiResponseMapper` and `ProblemDetailMapper` when Micronaut HTTP is present. `Response4jHttpServerFilter` applies `@SuccessResponse` wrapping to controller responses, and `Response4jExceptionHandler` maps exceptions to RFC 9457 Problem Details.
 
 Annotate controller methods or classes with `@SuccessResponse` and exception classes with `@ProblemResponse` the same way as with Spring Boot or Quarkus:
 
@@ -237,45 +237,45 @@ ProblemDetail problem = ProblemDetail.of("Not Found", 404, "Resource not found",
 
 ### `ApiResponse<T>`
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `status` | `int` | HTTP status code |
-| `message` | `String` | Human-readable message |
+| Field       | Type      | Description              |
+|-------------|-----------|--------------------------|
+| `status`    | `int`     | HTTP status code         |
+| `message`   | `String`  | Human-readable message   |
 | `timestamp` | `Instant` | UTC timestamp (ISO-8601) |
-| `data` | `T` | Optional payload |
+| `data`      | `T`       | Optional payload         |
 
 Factory methods: `of(status, message, data)`, `empty(status, message)`, `ok(data)`, `created(data)`, `noContent()`.
 
 ### `ProblemDetail`
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `type` | `URI` | Problem type (RFC 7807) |
-| `title` | `String` | Short summary |
-| `status` | `int` | HTTP status |
-| `detail` | `String` | Explanation for this occurrence |
-| `instance` | `String` | Optional instance URI |
-| `extensions` | `Map<String, Object>` | Optional extra fields |
+| Field        | Type                  | Description                     |
+|--------------|-----------------------|---------------------------------|
+| `type`       | `URI`                 | Problem type (RFC 9457)         |
+| `title`      | `String`              | Short summary                   |
+| `status`     | `int`                 | HTTP status                     |
+| `detail`     | `String`              | Explanation for this occurrence |
+| `instance`   | `String`              | Optional instance URI           |
+| `extensions` | `Map<String, Object>` | Optional extra fields           |
 
 Factory method: `of(title, status, detail, instance, extensions)`.
 
 ### `@SuccessResponse`
 
-| Attribute | Default | Description |
-|-----------|---------|-------------|
-| `status` | `200` | HTTP status code |
-| `message` | `"Request successful"` | Message in the response |
-| `wrap` | `true` | Wrap in `ApiResponse`; if `false`, return body as-is |
+| Attribute | Default                | Description                                          |
+|-----------|------------------------|------------------------------------------------------|
+| `status`  | `200`                  | HTTP status code                                     |
+| `message` | `"Request successful"` | Message in the response                              |
+| `wrap`    | `true`                 | Wrap in `ApiResponse`; if `false`, return body as-is |
 
 ### `@ProblemResponse`
 
-| Attribute | Default | Description |
-|-----------|---------|-------------|
-| `status` | `500` | HTTP status code |
-| `title` | `""` (falls back to exception class name) | Short summary |
-| `type` | `"about:blank"` | Problem type URI |
-| `detail` | `""` | Detail text |
-| `includeExceptionMessage` | `true` | Use exception message as detail when `detail` is blank |
+| Attribute                 | Default                                   | Description                                                                                     |
+|---------------------------|-------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `status`                  | `500`                                     | HTTP status code                                                                                |
+| `title`                   | `""` (falls back to exception class name) | Short summary                                                                                   |
+| `type`                    | `"about:blank"`                           | Problem type URI (RFC 9457 Section 4.2.1: when `about:blank`, title must be HTTP reason phrase) |
+| `detail`                  | `""`                                      | Detail text                                                                                     |
+| `includeExceptionMessage` | `true`                                    | Use exception message as detail when `detail` is blank                                          |
 
 ## Project Structure
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <name>response4j</name>
-    <description>A framework-agnostic Java library for standardized API error responses aligned with RFC 7807 Problem Details</description>
+    <description>A framework-agnostic Java library for standardized API error responses aligned with RFC 9457 Problem Details for HTTP APIs</description>
     <url>https://github.com/iamkavindu/response4j</url>
 
     <licenses>

--- a/response4j-core/src/main/java/io/github/iamkavindu/response4j/annotation/ProblemExtension.java
+++ b/response4j-core/src/main/java/io/github/iamkavindu/response4j/annotation/ProblemExtension.java
@@ -1,0 +1,61 @@
+package io.github.iamkavindu.response4j.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a problem-specific extension member to be included in the RFC 9457
+ * {@link io.github.iamkavindu.response4j.model.ProblemDetail} response.
+ * <p>
+ * Per RFC 9457, producers may add additional members (extensions) to convey problem-specific
+ * information beyond the standard fields. This annotation allows statically declaring these
+ * extensions on exception classes, which are then automatically included in the problem detail
+ * response as top-level JSON properties.
+ * <p>
+ * This annotation is {@link Repeatable}, so multiple extensions can be declared on a single
+ * exception class by applying the annotation multiple times or using the {@link ProblemExtensions}
+ * container annotation.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * @ProblemResponse(status = 400, title = "Validation Error",
+ *     type = "https://api.example.com/errors/validation")
+ * @ProblemExtension(key = "docs", value = "https://api.example.com/docs/errors/validation")
+ * @ProblemExtension(key = "supportEmail", value = "support@example.com")
+ * public class ValidationException extends RuntimeException {
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * @see ProblemExtensions
+ * @see ProblemResponse
+ * @see io.github.iamkavindu.response4j.model.ProblemDetail
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9457#section-3">RFC 9457 Section 3</a>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Repeatable(ProblemExtensions.class)
+public @interface ProblemExtension {
+    /**
+     * The extension field name (key) to be included in the problem detail response.
+     * <p>
+     * This will appear as a top-level JSON property alongside the standard RFC 9457 fields.
+     *
+     * @return the extension field name
+     */
+    String key();
+
+    /**
+     * The extension field value.
+     * <p>
+     * This will be serialized as a string in the problem detail response.
+     *
+     * @return the extension field value
+     */
+    String value();
+}

--- a/response4j-core/src/main/java/io/github/iamkavindu/response4j/annotation/ProblemExtensions.java
+++ b/response4j-core/src/main/java/io/github/iamkavindu/response4j/annotation/ProblemExtensions.java
@@ -1,0 +1,43 @@
+package io.github.iamkavindu.response4j.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Container annotation for multiple {@link ProblemExtension} annotations.
+ * <p>
+ * This annotation is automatically applied by the Java compiler when multiple
+ * {@link ProblemExtension} annotations are used on the same element, due to the
+ * {@link java.lang.annotation.Repeatable} meta-annotation on {@link ProblemExtension}.
+ * <p>
+ * You typically don't need to use this annotation directly; instead, apply multiple
+ * {@link ProblemExtension} annotations, and the compiler will generate this container
+ * annotation automatically.
+ * <p>
+ * Example usage (the compiler handles this automatically):
+ * <pre>{@code
+ * @ProblemResponse(status = 400, title = "Validation Error")
+ * @ProblemExtension(key = "docs", value = "https://api.example.com/docs")
+ * @ProblemExtension(key = "supportEmail", value = "support@example.com")
+ * public class ValidationException extends RuntimeException {
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * @see ProblemExtension
+ * @see ProblemResponse
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ProblemExtensions {
+    /**
+     * The array of {@link ProblemExtension} annotations.
+     *
+     * @return the contained extension annotations
+     */
+    ProblemExtension[] value();
+}

--- a/response4j-core/src/main/java/io/github/iamkavindu/response4j/annotation/ProblemResponse.java
+++ b/response4j-core/src/main/java/io/github/iamkavindu/response4j/annotation/ProblemResponse.java
@@ -7,12 +7,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks an exception class for RFC 7807 Problem Details mapping.
+ * Marks an exception class for RFC 9457 Problem Details mapping.
  * <p>
  * When an annotated exception is thrown, it is mapped to a {@link io.github.iamkavindu.response4j.model.ProblemDetail}
  * using the values specified here. Blank values fall back to defaults (e.g. exception class name for title).
  *
  * @see io.github.iamkavindu.response4j.model.ProblemDetail
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC 9457: Problem Details for HTTP APIs</a>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -33,9 +34,13 @@ public @interface ProblemResponse {
     String title() default "";
 
     /**
-     * URI reference identifying the problem type (RFC 7807).
+     * URI reference identifying the problem type (RFC 9457).
+     * <p>
+     * Per RFC 9457 Section 4.2.1, when this is {@code "about:blank"}, the title MUST be
+     * the HTTP reason phrase for the status code (e.g., "Not Found" for 404).
      *
      * @return the type URI
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc9457#section-4.2.1">RFC 9457 Section 4.2.1</a>
      */
     String type() default "about:blank";
 

--- a/response4j-core/src/main/java/io/github/iamkavindu/response4j/mapper/ProblemDetailMapper.java
+++ b/response4j-core/src/main/java/io/github/iamkavindu/response4j/mapper/ProblemDetailMapper.java
@@ -1,17 +1,24 @@
 package io.github.iamkavindu.response4j.mapper;
 
+import io.github.iamkavindu.response4j.annotation.ProblemExtension;
 import io.github.iamkavindu.response4j.annotation.ProblemResponse;
 import io.github.iamkavindu.response4j.model.ProblemDetail;
+import io.github.iamkavindu.response4j.model.ProblemTypes;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
- * Maps {@link Throwable} instances to {@link ProblemDetail} RFC 7807 representations.
+ * Maps {@link Throwable} instances to {@link ProblemDetail} RFC 9457 representations.
  * <p>
  * When the exception class is annotated with {@link ProblemResponse}, uses the annotation values
  * (with fallbacks for blank title/detail). Otherwise, returns a generic 500 "Internal Server Error"
  * problem detail.
+ * <p>
+ * Per RFC 9457 Section 4.2.1, when the type is {@code about:blank}, the title MUST be the HTTP
+ * reason phrase for the status code (e.g., "Not Found" for 404).
  */
 public class ProblemDetailMapper {
 
@@ -26,39 +33,148 @@ public class ProblemDetailMapper {
      * @return a {@code ProblemDetail} representing the error
      */
     public ProblemDetail map(Throwable exception) {
+        return map(exception, null);
+    }
+
+    /**
+     * Maps the given exception to a {@code ProblemDetail} with a specific instance URI.
+     * <p>
+     * If the exception class has {@link ProblemResponse}, uses its status, title, type, and detail.
+     * Blank title defaults to the exception class simple name. Blank detail defaults to the
+     * exception message when {@code includeExceptionMessage} is true.
+     * <p>
+     * The {@code instance} parameter is used to populate the RFC 9457 "instance" field, which
+     * identifies the specific occurrence of the problem. Typically, this is set to the request URI
+     * that triggered the error.
+     *
+     * @param exception the exception to map
+     * @param instance  the URI reference identifying the specific occurrence of the problem, or {@code null}
+     * @return a {@code ProblemDetail} representing the error with the instance field set
+     */
+    public ProblemDetail map(Throwable exception, String instance) {
         ProblemResponse annotation = exception.getClass()
                 .getAnnotation(ProblemResponse.class);
 
         if (annotation != null) {
-            return mapFromAnnotation(exception, annotation);
+            return mapFromAnnotation(exception, annotation, instance);
         }
 
-        return mapWithDefaults(exception);
+        return mapWithDefaults(exception, instance);
     }
 
-    private ProblemDetail mapFromAnnotation(Throwable exception, ProblemResponse annotation) {
-        String title = annotation.title().isBlank()
-                ? exception.getClass().getSimpleName()
-                : annotation.title();
+    /**
+     * Resolves the HTTP reason phrase for the given status code.
+     * <p>
+     * This method returns the canonical HTTP reason phrase as defined in RFC 9110.
+     * For unknown status codes, it returns "HTTP Error {status}".
+     *
+     * @param status the HTTP status code
+     * @return the HTTP reason phrase for the status code
+     */
+    private static String httpReasonPhrase(int status) {
+        return switch (status) {
+            case 400 -> "Bad Request";
+            case 401 -> "Unauthorized";
+            case 402 -> "Payment Required";
+            case 403 -> "Forbidden";
+            case 404 -> "Not Found";
+            case 405 -> "Method Not Allowed";
+            case 406 -> "Not Acceptable";
+            case 407 -> "Proxy Authentication Required";
+            case 408 -> "Request Timeout";
+            case 409 -> "Conflict";
+            case 410 -> "Gone";
+            case 411 -> "Length Required";
+            case 412 -> "Precondition Failed";
+            case 413 -> "Content Too Large";
+            case 414 -> "URI Too Long";
+            case 415 -> "Unsupported Media Type";
+            case 416 -> "Range Not Satisfiable";
+            case 417 -> "Expectation Failed";
+            case 421 -> "Misdirected Request";
+            case 422 -> "Unprocessable Content";
+            case 423 -> "Locked";
+            case 424 -> "Failed Dependency";
+            case 425 -> "Too Early";
+            case 426 -> "Upgrade Required";
+            case 428 -> "Precondition Required";
+            case 429 -> "Too Many Requests";
+            case 431 -> "Request Header Fields Too Large";
+            case 451 -> "Unavailable For Legal Reasons";
+            case 500 -> "Internal Server Error";
+            case 501 -> "Not Implemented";
+            case 502 -> "Bad Gateway";
+            case 503 -> "Service Unavailable";
+            case 504 -> "Gateway Timeout";
+            case 505 -> "HTTP Version Not Supported";
+            case 506 -> "Variant Also Negotiates";
+            case 507 -> "Insufficient Storage";
+            case 508 -> "Loop Detected";
+            case 510 -> "Not Extended";
+            case 511 -> "Network Authentication Required";
+            default  -> "HTTP Error " + status;
+        };
+    }
+
+    private ProblemDetail mapFromAnnotation(Throwable exception, ProblemResponse annotation, String instance) {
+        URI type = URI.create(annotation.type());
+        int status = annotation.status();
+        
+        // Per RFC 9457 Section 4.2.1: when type is about:blank, title MUST be HTTP reason phrase
+        String title;
+        if (ProblemTypes.ABOUT_BLANK.equals(type) && annotation.title().isBlank()) {
+            title = httpReasonPhrase(status);
+        } else {
+            title = annotation.title().isBlank()
+                    ? exception.getClass().getSimpleName()
+                    : annotation.title();
+        }
 
         String detail = annotation.detail().isBlank() && annotation.includeExceptionMessage()
                 ? Objects.requireNonNullElse(exception.getMessage(), "")
                 : annotation.detail();
 
+        // Extract extension members from @ProblemExtension annotations
+        Map<String, Object> extensions = extractExtensions(exception);
+
         return new ProblemDetail.Builder()
-                .type(URI.create(annotation.type()))
-                .status(annotation.status())
+                .type(type)
+                .status(status)
                 .title(title)
                 .detail(detail)
+                .instance(instance)
+                .extensions(extensions.isEmpty() ? null : extensions)
                 .build();
     }
 
-    private ProblemDetail mapWithDefaults(Throwable exception) {
+    /**
+     * Extracts problem-specific extension members from {@link ProblemExtension} annotations
+     * on the exception class.
+     *
+     * @param exception the exception to extract extensions from
+     * @return a map of extension field names to values; empty if no extensions are present
+     */
+    private Map<String, Object> extractExtensions(Throwable exception) {
+        Map<String, Object> extensions = new HashMap<>();
+        
+        ProblemExtension[] extensionAnnotations = exception.getClass()
+                .getAnnotationsByType(ProblemExtension.class);
+        
+        for (ProblemExtension ext : extensionAnnotations) {
+            extensions.put(ext.key(), ext.value());
+        }
+        
+        return extensions;
+    }
+
+    private ProblemDetail mapWithDefaults(Throwable exception, String instance) {
+        int status = 500;
         return new ProblemDetail.Builder()
-                .type(URI.create("about:blank"))
-                .status(500)
-                .title("Internal Server Error")
+                .type(ProblemTypes.ABOUT_BLANK)
+                .status(status)
+                .title(httpReasonPhrase(status))
                 .detail(Objects.requireNonNullElse(exception.getMessage(), ""))
+                .instance(instance)
                 .build();
     }
 }

--- a/response4j-core/src/main/java/io/github/iamkavindu/response4j/model/ProblemDetail.java
+++ b/response4j-core/src/main/java/io/github/iamkavindu/response4j/model/ProblemDetail.java
@@ -4,14 +4,15 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 /**
- * RFC 7807 Problem Details for HTTP APIs representation.
+ * RFC 9457 Problem Details for HTTP APIs representation.
  * <p>
  * This immutable record provides a standardized, machine-readable format for specifying
  * errors in HTTP API responses, following the specification defined in
- * <a href="https://www.rfc-editor.org/rfc/rfc7807">RFC 7807</a>.
+ * <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC 9457</a>.
  * <p>
  * Problem details include a problem type URI, title, status code, human-readable detail,
  * optional instance identifier, and extensible additional properties. This record is
@@ -25,25 +26,26 @@ import java.util.Map;
  * <p>
  * JSON serialization is handled by Jackson annotations. The {@code extensions} map is flattened
  * into the JSON output using {@link JsonAnyGetter}, allowing problem-specific extension members
- * to appear as top-level properties alongside the standard RFC 7807 fields.
+ * to appear as top-level properties alongside the standard RFC 9457 fields.
  * <p>
  * This record is thread-safe and immutable.
  *
- * @param type URI reference that identifies the problem type (RFC 7807 "type" member). Should resolve to
+ * @param type URI reference that identifies the problem type (RFC 9457 "type" member). Should resolve to
  *             human-readable documentation. Use {@code about:blank} when no specific type URI is available.
- * @param title short, human-readable summary of the problem type (RFC 7807 "title" member). Should not change
+ *             Per RFC 9457 Section 4.2.1, when type is {@code about:blank}, the title MUST be the HTTP reason phrase.
+ * @param title short, human-readable summary of the problem type (RFC 9457 "title" member). Should not change
  *              between occurrences of the same problem type, except for localization.
- * @param status HTTP status code for this occurrence of the problem (RFC 7807 "status" member)
- * @param detail human-readable explanation specific to this occurrence of the problem (RFC 7807 "detail" member);
+ * @param status HTTP status code for this occurrence of the problem (RFC 9457 "status" member)
+ * @param detail human-readable explanation specific to this occurrence of the problem (RFC 9457 "detail" member);
  *               may provide additional context beyond the title
- * @param instance URI reference identifying the specific occurrence of the problem (RFC 7807 "instance" member);
+ * @param instance URI reference identifying the specific occurrence of the problem (RFC 9457 "instance" member);
  *                 may be {@code null} if not applicable
  * @param extensions optional map of problem-specific extension members; serialized as top-level JSON properties
  *                   via {@link JsonAnyGetter}; may be {@code null}
  * @see io.github.iamkavindu.response4j.annotation.ProblemResponse
  * @see io.github.iamkavindu.response4j.mapper.ProblemDetailMapper
  * @see Builder
- * @see <a href="https://www.rfc-editor.org/rfc/rfc7807">RFC 7807: Problem Details for HTTP APIs</a>
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC 9457: Problem Details for HTTP APIs</a>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ProblemDetail(
@@ -55,17 +57,17 @@ public record ProblemDetail(
         @JsonAnyGetter Map<String, Object> extensions
 ) {
     /**
-     * Builder for constructing RFC 7807-compliant {@link ProblemDetail} instances using a fluent API.
+     * Builder for constructing RFC 9457-compliant {@link ProblemDetail} instances using a fluent API.
      * <p>
      * This builder allows step-by-step construction of a {@code ProblemDetail} with explicit
-     * control over all RFC 7807 standard and extension fields. For common use cases with sensible
+     * control over all RFC 9457 standard and extension fields. For common use cases with sensible
      * defaults, prefer the {@link ProblemDetail#of(String, int, String, String, Map)} factory method.
      * <p>
      * The builder is typically used by the {@link io.github.iamkavindu.response4j.mapper.ProblemDetailMapper}
      * when mapping exceptions to problem details.
      *
      * @see ProblemDetail
-     * @see <a href="https://www.rfc-editor.org/rfc/rfc7807">RFC 7807: Problem Details for HTTP APIs</a>
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC 9457: Problem Details for HTTP APIs</a>
      */
     public static class Builder {
         private URI type;
@@ -78,12 +80,14 @@ public record ProblemDetail(
         /**
          * Sets the problem type URI.
          * <p>
-         * Per RFC 7807, this should be a URI reference that identifies the problem type and
+         * Per RFC 9457, this should be a URI reference that identifies the problem type and
          * ideally resolves to human-readable documentation. Use {@code URI.create("about:blank")}
-         * when no specific documentation is available.
+         * when no specific documentation is available. Per RFC 9457 Section 4.2.1, when type is
+         * {@code about:blank}, the title MUST be the HTTP reason phrase for the status code.
          *
          * @param type the problem type URI
          * @return this builder for method chaining
+         * @see <a href="https://www.rfc-editor.org/rfc/rfc9457#section-4.2.1">RFC 9457 Section 4.2.1</a>
          */
         public Builder type(URI type) {
             this.type = type;
@@ -93,7 +97,7 @@ public record ProblemDetail(
         /**
          * Sets the problem title.
          * <p>
-         * Per RFC 7807, this should be a short, human-readable summary of the problem type.
+         * Per RFC 9457, this should be a short, human-readable summary of the problem type.
          * The title should remain consistent across different occurrences of the same problem type.
          *
          * @param title the problem title
@@ -107,7 +111,7 @@ public record ProblemDetail(
         /**
          * Sets the HTTP status code.
          * <p>
-         * Per RFC 7807, this is the HTTP status code generated by the origin server for
+         * Per RFC 9457, this is the HTTP status code generated by the origin server for
          * this occurrence of the problem.
          *
          * @param status the HTTP status code (e.g., 400, 404, 500)
@@ -121,7 +125,7 @@ public record ProblemDetail(
         /**
          * Sets the problem detail.
          * <p>
-         * Per RFC 7807, this should be a human-readable explanation specific to this
+         * Per RFC 9457, this should be a human-readable explanation specific to this
          * occurrence of the problem, providing additional context beyond the title.
          *
          * @param detail the problem detail explanation
@@ -135,7 +139,7 @@ public record ProblemDetail(
         /**
          * Sets the instance identifier.
          * <p>
-         * Per RFC 7807, this is a URI reference that identifies the specific occurrence
+         * Per RFC 9457, this is a URI reference that identifies the specific occurrence
          * of the problem. It may be used to reference the problem in logs or support tickets.
          *
          * @param instance the instance URI reference, or {@code null} if not applicable
@@ -149,9 +153,9 @@ public record ProblemDetail(
         /**
          * Sets problem-specific extension members.
          * <p>
-         * Per RFC 7807, producers may add additional members to convey problem-specific
+         * Per RFC 9457, producers may add additional members to convey problem-specific
          * information. These extensions will be serialized as top-level JSON properties
-         * alongside the standard RFC 7807 fields.
+         * alongside the standard RFC 9457 fields.
          *
          * @param extensions map of extension field names to values, or {@code null} if no extensions
          * @return this builder for method chaining
@@ -164,7 +168,7 @@ public record ProblemDetail(
         /**
          * Constructs an immutable {@link ProblemDetail} with the configured values.
          *
-         * @return a new RFC 7807-compliant {@code ProblemDetail} instance
+         * @return a new RFC 9457-compliant {@code ProblemDetail} instance
          */
         public ProblemDetail build() {
             return new ProblemDetail(type, title, status, detail, instance, extensions);
@@ -175,7 +179,7 @@ public record ProblemDetail(
      * Creates a {@code ProblemDetail} with the specified fields and a default type URI.
      * <p>
      * This factory method constructs a problem detail with the problem type set to
-     * {@code about:blank} per RFC 7807 conventions (indicating no specific problem type
+     * {@code about:blank} per RFC 9457 conventions (indicating no specific problem type
      * documentation is available). For more control over the type URI, use the {@link Builder}.
      * <p>
      * This method is typically used for ad-hoc error responses or when the
@@ -187,18 +191,61 @@ public record ProblemDetail(
      * @param detail human-readable explanation specific to this occurrence
      * @param instance URI reference identifying the specific occurrence, or {@code null}
      * @param extensions map of problem-specific extension members, or {@code null}
-     * @return a new RFC 7807-compliant {@code ProblemDetail} instance with type {@code about:blank}
+     * @return a new RFC 9457-compliant {@code ProblemDetail} instance with type {@code about:blank}
      * @see Builder
-     * @see <a href="https://www.rfc-editor.org/rfc/rfc7807">RFC 7807: Problem Details for HTTP APIs</a>
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC 9457: Problem Details for HTTP APIs</a>
      */
     public static ProblemDetail of(String title, int status, String detail, String instance, Map<String, Object> extensions) {
         return new ProblemDetail.Builder()
-                .type(URI.create("about:blank"))
+                .type(ProblemTypes.ABOUT_BLANK)
                 .title(title)
                 .status(status)
                 .detail(detail)
                 .instance(instance)
                 .extensions(extensions)
+                .build();
+    }
+
+    /**
+     * Creates a {@code ProblemDetail} carrying multiple sub-errors in the {@code "errors"} extension field.
+     * <p>
+     * This factory method is suitable for validation failures or any scenario with multiple simultaneous
+     * problems. The {@code errors} list is placed in the extensions map under the key {@code "errors"},
+     * following the RFC 9457 Section 3 recommendation for multi-problem responses.
+     * <p>
+     * Per RFC 9457 Section 3, a single Problem Detail response represents a single logical problem.
+     * For cases involving multiple problems (e.g., bean validation failures across several fields),
+     * the spec recommends carrying aggregated sub-errors via extension members.
+     * <p>
+     * Example usage:
+     * <pre>{@code
+     * List<ProblemDetailError> errors = List.of(
+     *     new ProblemDetailError("/email", "must be a valid email address"),
+     *     new ProblemDetailError("/age", "must be at least 18")
+     * );
+     * ProblemDetail problem = ProblemDetail.ofErrors(
+     *     "Validation Failed",
+     *     400,
+     *     "The request contains invalid fields",
+     *     errors
+     * );
+     * }</pre>
+     *
+     * @param title  short summary of the problem type
+     * @param status HTTP status code for this occurrence of the problem
+     * @param detail overall explanation of the problem
+     * @param errors list of field-level or sub-errors; may be empty but not {@code null}
+     * @return a new {@code ProblemDetail} with the errors embedded as an extension under the key {@code "errors"}
+     * @see ProblemDetailError
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc9457#section-3">RFC 9457 Section 3</a>
+     */
+    public static ProblemDetail ofErrors(String title, int status, String detail, List<ProblemDetailError> errors) {
+        return new ProblemDetail.Builder()
+                .type(ProblemTypes.ABOUT_BLANK)
+                .title(title)
+                .status(status)
+                .detail(detail)
+                .extensions(Map.of("errors", errors))
                 .build();
     }
 }

--- a/response4j-core/src/main/java/io/github/iamkavindu/response4j/model/ProblemDetailError.java
+++ b/response4j-core/src/main/java/io/github/iamkavindu/response4j/model/ProblemDetailError.java
@@ -1,0 +1,37 @@
+package io.github.iamkavindu.response4j.model;
+
+/**
+ * Represents a single sub-error within a multi-problem response,
+ * intended to be carried as an extension member in {@link ProblemDetail}.
+ * <p>
+ * Use this in the {@code extensions} map under the key {@code "errors"} to
+ * communicate multiple validation or field-level failures in a single response,
+ * following the pattern recommended by RFC 9457 Section 3.
+ * <p>
+ * RFC 9457 Section 3 provides guidance that a single Problem Detail response represents
+ * a single logical problem. For cases involving multiple problems (e.g., bean validation
+ * failures across several fields), the spec recommends carrying aggregated sub-errors via
+ * extension members like this record.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * List<ProblemDetailError> errors = List.of(
+ *     new ProblemDetailError("/email", "must be a valid email address"),
+ *     new ProblemDetailError("/age", "must be at least 18")
+ * );
+ * ProblemDetail problem = ProblemDetail.ofErrors(
+ *     "Validation Failed",
+ *     400,
+ *     "The request contains invalid fields",
+ *     errors
+ * );
+ * }</pre>
+ *
+ * @param pointer a JSON Pointer (RFC 6901) or field name identifying the source of the error
+ * @param detail  human-readable explanation of this specific error
+ * @see ProblemDetail#ofErrors(String, int, String, java.util.List)
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9457#section-3">RFC 9457 Section 3</a>
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc6901">RFC 6901: JSON Pointer</a>
+ */
+public record ProblemDetailError(String pointer, String detail) {
+}

--- a/response4j-core/src/main/java/io/github/iamkavindu/response4j/model/ProblemTypes.java
+++ b/response4j-core/src/main/java/io/github/iamkavindu/response4j/model/ProblemTypes.java
@@ -1,0 +1,44 @@
+package io.github.iamkavindu.response4j.model;
+
+import java.net.URI;
+
+/**
+ * Constants for well-known problem type URIs registered in the
+ * IANA HTTP Problem Types registry, as defined by RFC 9457 Section 4.2.
+ * <p>
+ * These constants provide a type-safe, discoverable way to reference standard
+ * problem type URIs instead of using raw strings. As the IANA registry grows,
+ * additional constants will be added here.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9457#section-4.2">RFC 9457 Section 4.2</a>
+ * @see <a href="https://www.iana.org/assignments/http-problem-types">IANA HTTP Problem Types Registry</a>
+ */
+public final class ProblemTypes {
+
+    private ProblemTypes() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Base URI for IANA-registered problem types.
+     * <p>
+     * This can be used as a prefix for constructing problem type URIs registered
+     * in the IANA HTTP Problem Types registry.
+     */
+    public static final String IANA_BASE = "https://iana.org/assignments/http-problem-types#";
+
+    /**
+     * The {@code about:blank} problem type URI.
+     * <p>
+     * Per RFC 9457 Section 4.2.1, this indicates that no specific problem type
+     * documentation is available. When this type is used, the {@code title} field
+     * MUST be the HTTP reason phrase for the status code (e.g., "Not Found" for 404,
+     * "Internal Server Error" for 500).
+     *
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc9457#section-4.2.1">RFC 9457 Section 4.2.1</a>
+     */
+    public static final URI ABOUT_BLANK = URI.create("about:blank");
+
+    // Future IANA registrations can be added here as the registry grows.
+    // Example: public static final URI VALIDATION_FAILED = URI.create(IANA_BASE + "validation");
+}

--- a/response4j-core/src/test/java/io/github/iamkavindu/response4j/mapper/ProblemDetailMapperTest.java
+++ b/response4j-core/src/test/java/io/github/iamkavindu/response4j/mapper/ProblemDetailMapperTest.java
@@ -1,0 +1,199 @@
+package io.github.iamkavindu.response4j.mapper;
+
+import io.github.iamkavindu.response4j.annotation.ProblemExtension;
+import io.github.iamkavindu.response4j.annotation.ProblemResponse;
+import io.github.iamkavindu.response4j.model.ProblemDetail;
+import io.github.iamkavindu.response4j.model.ProblemTypes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ProblemDetailMapper}.
+ */
+class ProblemDetailMapperTest {
+
+    private ProblemDetailMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ProblemDetailMapper();
+    }
+
+    @Test
+    void mapShouldReturnInternalServerErrorForUnAnnotatedException() {
+        Exception exception = new RuntimeException("Something went wrong");
+
+        ProblemDetail problem = mapper.map(exception);
+
+        assertEquals(ProblemTypes.ABOUT_BLANK, problem.type());
+        assertEquals("Internal Server Error", problem.title()); // RFC 9457: about:blank requires HTTP reason phrase
+        assertEquals(500, problem.status());
+        assertEquals("Something went wrong", problem.detail());
+        assertNull(problem.instance());
+    }
+
+    @Test
+    void mapShouldUseAnnotationValues() {
+        Exception exception = new TestNotFoundException(42L);
+
+        ProblemDetail problem = mapper.map(exception);
+
+        assertEquals(URI.create("https://api.example.com/errors/not-found"), problem.type());
+        assertEquals("Resource Not Found", problem.title());
+        assertEquals(404, problem.status());
+        assertEquals("User with id 42 not found", problem.detail());
+    }
+
+    @Test
+    void mapShouldUseHttpReasonPhraseWhenTypeIsAboutBlankAndTitleIsBlank() {
+        Exception exception = new TestBadRequestException();
+
+        ProblemDetail problem = mapper.map(exception);
+
+        assertEquals(ProblemTypes.ABOUT_BLANK, problem.type());
+        assertEquals("Bad Request", problem.title()); // RFC 9457 Section 4.2.1
+        assertEquals(400, problem.status());
+    }
+
+    @Test
+    void mapShouldUseExceptionClassNameWhenTitleIsBlankAndTypeIsNotAboutBlank() {
+        Exception exception = new TestValidationException();
+
+        ProblemDetail problem = mapper.map(exception);
+
+        assertEquals(URI.create("https://api.example.com/errors/validation"), problem.type());
+        assertEquals("TestValidationException", problem.title()); // Falls back to class name
+        assertEquals(400, problem.status());
+    }
+
+    @Test
+    void mapWithInstanceShouldPopulateInstanceField() {
+        Exception exception = new TestNotFoundException(42L);
+
+        ProblemDetail problem = mapper.map(exception, "/api/users/42");
+
+        assertEquals("/api/users/42", problem.instance());
+    }
+
+    @Test
+    void mapShouldIncludeExtensionsFromAnnotation() {
+        Exception exception = new TestExceptionWithExtensions();
+
+        ProblemDetail problem = mapper.map(exception);
+
+        assertNotNull(problem.extensions());
+        assertEquals("https://api.example.com/docs", problem.extensions().get("docs"));
+        assertEquals("support@example.com", problem.extensions().get("supportEmail"));
+    }
+
+    @Test
+    void mapShouldHandleMultipleExtensions() {
+        Exception exception = new TestExceptionWithMultipleExtensions();
+
+        ProblemDetail problem = mapper.map(exception);
+
+        assertNotNull(problem.extensions());
+        assertEquals(3, problem.extensions().size());
+        assertEquals("value1", problem.extensions().get("key1"));
+        assertEquals("value2", problem.extensions().get("key2"));
+        assertEquals("value3", problem.extensions().get("key3"));
+    }
+
+    @Test
+    void mapShouldNotIncludeExtensionsWhenNonePresent() {
+        Exception exception = new TestNotFoundException(42L);
+
+        ProblemDetail problem = mapper.map(exception);
+
+        assertNull(problem.extensions());
+    }
+
+    @Test
+    void mapShouldUseHttpReasonPhraseFor404() {
+        Exception exception = new TestNotFoundException(42L);
+
+        ProblemDetail problem = mapper.map(exception);
+
+        // Even though annotation has a custom type, title is set
+        assertEquals("Resource Not Found", problem.title());
+    }
+
+    @Test
+    void mapShouldHandleNullExceptionMessage() {
+        Exception exception = new TestExceptionWithNullMessage();
+
+        ProblemDetail problem = mapper.map(exception);
+
+        assertEquals("", problem.detail());
+    }
+
+    // Test exception classes
+
+    @ProblemResponse(
+            status = 404,
+            title = "Resource Not Found",
+            type = "https://api.example.com/errors/not-found"
+    )
+    static class TestNotFoundException extends RuntimeException {
+        public TestNotFoundException(Long id) {
+            super("User with id " + id + " not found");
+        }
+    }
+
+    @ProblemResponse(
+            status = 400
+    )
+    static class TestBadRequestException extends RuntimeException {
+        public TestBadRequestException() {
+            super("Invalid request");
+        }
+    }
+
+    @ProblemResponse(
+            status = 400,
+            type = "https://api.example.com/errors/validation"
+            // title is blank but type is not about:blank, should use class name
+    )
+    static class TestValidationException extends RuntimeException {
+        public TestValidationException() {
+            super("Validation failed");
+        }
+    }
+
+    @ProblemResponse(
+            status = 400,
+            title = "Test Error"
+    )
+    @ProblemExtension(key = "docs", value = "https://api.example.com/docs")
+    @ProblemExtension(key = "supportEmail", value = "support@example.com")
+    static class TestExceptionWithExtensions extends RuntimeException {
+        public TestExceptionWithExtensions() {
+            super("Test error with extensions");
+        }
+    }
+
+    @ProblemResponse(
+            title = "Internal Error"
+    )
+    @ProblemExtension(key = "key1", value = "value1")
+    @ProblemExtension(key = "key2", value = "value2")
+    @ProblemExtension(key = "key3", value = "value3")
+    static class TestExceptionWithMultipleExtensions extends RuntimeException {
+        public TestExceptionWithMultipleExtensions() {
+            super("Multiple extensions");
+        }
+    }
+
+    @ProblemResponse(
+            title = "Null Message Error"
+    )
+    static class TestExceptionWithNullMessage extends RuntimeException {
+        public TestExceptionWithNullMessage() {
+            super((String) null);
+        }
+    }
+}

--- a/response4j-core/src/test/java/io/github/iamkavindu/response4j/model/ProblemDetailErrorTest.java
+++ b/response4j-core/src/test/java/io/github/iamkavindu/response4j/model/ProblemDetailErrorTest.java
@@ -1,0 +1,44 @@
+package io.github.iamkavindu.response4j.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ProblemDetailError} record.
+ */
+class ProblemDetailErrorTest {
+
+    @Test
+    void shouldCreateErrorWithPointerAndDetail() {
+        ProblemDetailError error = new ProblemDetailError("/email", "must be a valid email address");
+        
+        assertEquals("/email", error.pointer());
+        assertEquals("must be a valid email address", error.detail());
+    }
+
+    @Test
+    void shouldSupportJsonPointerFormat() {
+        ProblemDetailError error = new ProblemDetailError("/user/profile/age", "must be at least 18");
+        
+        assertTrue(error.pointer().startsWith("/"));
+        assertEquals("must be at least 18", error.detail());
+    }
+
+    @Test
+    void shouldSupportFieldNameFormat() {
+        ProblemDetailError error = new ProblemDetailError("username", "is already taken");
+        
+        assertEquals("username", error.pointer());
+        assertEquals("is already taken", error.detail());
+    }
+
+    @Test
+    void shouldBeImmutable() {
+        ProblemDetailError error1 = new ProblemDetailError("/field", "error message");
+        ProblemDetailError error2 = new ProblemDetailError("/field", "error message");
+        
+        assertEquals(error1, error2);
+        assertEquals(error1.hashCode(), error2.hashCode());
+    }
+}

--- a/response4j-core/src/test/java/io/github/iamkavindu/response4j/model/ProblemDetailTest.java
+++ b/response4j-core/src/test/java/io/github/iamkavindu/response4j/model/ProblemDetailTest.java
@@ -1,0 +1,119 @@
+package io.github.iamkavindu.response4j.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ProblemDetail} record.
+ */
+class ProblemDetailTest {
+
+    @Test
+    void ofShouldCreateProblemDetailWithAboutBlank() {
+        ProblemDetail problem = ProblemDetail.of(
+            "Not Found",
+            404,
+            "User with id 42 not found",
+            "/users/42",
+            null
+        );
+
+        assertEquals(ProblemTypes.ABOUT_BLANK, problem.type());
+        assertEquals("Not Found", problem.title());
+        assertEquals(404, problem.status());
+        assertEquals("User with id 42 not found", problem.detail());
+        assertEquals("/users/42", problem.instance());
+        assertNull(problem.extensions());
+    }
+
+    @Test
+    void ofShouldSupportExtensions() {
+        Map<String, Object> extensions = Map.of(
+            "traceId", "abc-123",
+            "timestamp", "2024-01-15T10:30:00Z"
+        );
+
+        ProblemDetail problem = ProblemDetail.of(
+            "Internal Server Error",
+            500,
+            "Database connection failed",
+            "/api/users",
+            extensions
+        );
+
+        assertNotNull(problem.extensions());
+        assertEquals("abc-123", problem.extensions().get("traceId"));
+        assertEquals("2024-01-15T10:30:00Z", problem.extensions().get("timestamp"));
+    }
+
+    @Test
+    void ofErrorsShouldCreateProblemDetailWithErrorsList() {
+        List<ProblemDetailError> errors = List.of(
+            new ProblemDetailError("/email", "must be a valid email address"),
+            new ProblemDetailError("/age", "must be at least 18")
+        );
+
+        ProblemDetail problem = ProblemDetail.ofErrors(
+            "Validation Failed",
+            400,
+            "The request contains invalid fields",
+            errors
+        );
+
+        assertEquals(ProblemTypes.ABOUT_BLANK, problem.type());
+        assertEquals("Validation Failed", problem.title());
+        assertEquals(400, problem.status());
+        assertEquals("The request contains invalid fields", problem.detail());
+        assertNotNull(problem.extensions());
+        assertTrue(problem.extensions().containsKey("errors"));
+        
+        @SuppressWarnings("unchecked")
+        List<ProblemDetailError> extractedErrors = (List<ProblemDetailError>) problem.extensions().get("errors");
+        assertEquals(2, extractedErrors.size());
+        assertEquals("/email", extractedErrors.getFirst().pointer());
+        assertEquals("must be a valid email address", extractedErrors.getFirst().detail());
+    }
+
+    @Test
+    void ofErrorsShouldHandleEmptyErrorsList() {
+        List<ProblemDetailError> errors = List.of();
+
+        ProblemDetail problem = ProblemDetail.ofErrors(
+            "Validation Failed",
+            400,
+            "The request contains invalid fields",
+            errors
+        );
+
+        assertNotNull(problem.extensions());
+        assertTrue(problem.extensions().containsKey("errors"));
+        
+        @SuppressWarnings("unchecked")
+        List<ProblemDetailError> extractedErrors = (List<ProblemDetailError>) problem.extensions().get("errors");
+        assertTrue(extractedErrors.isEmpty());
+    }
+
+    @Test
+    void builderShouldCreateProblemDetail() {
+        ProblemDetail problem = new ProblemDetail.Builder()
+            .type(ProblemTypes.ABOUT_BLANK)
+            .title("Bad Request")
+            .status(400)
+            .detail("Invalid input")
+            .instance("/api/test")
+            .extensions(Map.of("custom", "value"))
+            .build();
+
+        assertEquals(ProblemTypes.ABOUT_BLANK, problem.type());
+        assertEquals("Bad Request", problem.title());
+        assertEquals(400, problem.status());
+        assertEquals("Invalid input", problem.detail());
+        assertEquals("/api/test", problem.instance());
+        assertNotNull(problem.extensions());
+        assertEquals("value", problem.extensions().get("custom"));
+    }
+}

--- a/response4j-core/src/test/java/io/github/iamkavindu/response4j/model/ProblemTypesTest.java
+++ b/response4j-core/src/test/java/io/github/iamkavindu/response4j/model/ProblemTypesTest.java
@@ -1,0 +1,29 @@
+package io.github.iamkavindu.response4j.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ProblemTypes} constants.
+ */
+class ProblemTypesTest {
+
+    @Test
+    void aboutBlankShouldBeCorrectUri() {
+        assertEquals(URI.create("about:blank"), ProblemTypes.ABOUT_BLANK);
+    }
+
+    @Test
+    void aboutBlankShouldBeAboutScheme() {
+        assertEquals("about", ProblemTypes.ABOUT_BLANK.getScheme());
+        assertEquals("blank", ProblemTypes.ABOUT_BLANK.getSchemeSpecificPart());
+    }
+
+    @Test
+    void ianaBaseShouldBeCorrectString() {
+        assertEquals("https://iana.org/assignments/http-problem-types#", ProblemTypes.IANA_BASE);
+    }
+}

--- a/response4j-micronaut/src/main/java/io/github/iamkavindu/response4j/micronaut/filter/Response4jHttpServerFilter.java
+++ b/response4j-micronaut/src/main/java/io/github/iamkavindu/response4j/micronaut/filter/Response4jHttpServerFilter.java
@@ -3,7 +3,7 @@ package io.github.iamkavindu.response4j.micronaut.filter;
 import io.github.iamkavindu.response4j.annotation.SuccessResponse;
 import io.github.iamkavindu.response4j.mapper.ApiResponseMapper;
 import io.github.iamkavindu.response4j.model.ApiResponse;
-import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.BasicHttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
@@ -55,7 +55,7 @@ public class Response4jHttpServerFilter implements HttpServerFilter {
 
         if (response.getBody().orElse(null) instanceof ApiResponse<?>) {return response;}
 
-        RouteMatch<?> routeMatch = request.getAttribute(HttpAttributes.ROUTE_MATCH, RouteMatch.class)
+        RouteMatch<?> routeMatch = (RouteMatch<?>) BasicHttpAttributes.getRouteMatchInfo(request)
                 .orElse(null);
 
         if (routeMatch == null) {return response;}

--- a/response4j-micronaut/src/main/java/io/github/iamkavindu/response4j/micronaut/handler/Response4jExceptionHandler.java
+++ b/response4j-micronaut/src/main/java/io/github/iamkavindu/response4j/micronaut/handler/Response4jExceptionHandler.java
@@ -13,10 +13,13 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 /**
- * Micronaut exception handler that produces RFC 7807 {@link ProblemDetail} responses for all exceptions.
+ * Micronaut exception handler that produces RFC 9457 {@link ProblemDetail} responses for all exceptions.
  * <p>
  * Returns responses with {@code Content-Type: application/problem+json} and the appropriate
  * HTTP status from the mapped problem detail (or 500 for unmapped exceptions).
+ * <p>
+ * Per RFC 9457 Section 3.1, the {@code instance} field is populated with the request URI to help
+ * identify the specific occurrence of the problem.
  */
 @Singleton
 @Produces(MediaType.APPLICATION_JSON)
@@ -38,6 +41,9 @@ public class Response4jExceptionHandler implements ExceptionHandler<Exception, H
     /**
      * Handles the exception, mapping it to ProblemDetail and returning as
      * {@code application/problem+json}.
+     * <p>
+     * The request URI is passed to the mapper to populate the {@code instance} field,
+     * which identifies the specific occurrence of the problem per RFC 9457.
      *
      * @param request   the HTTP request
      * @param exception the thrown exception
@@ -45,7 +51,8 @@ public class Response4jExceptionHandler implements ExceptionHandler<Exception, H
      */
     @Override
     public HttpResponse<ProblemDetail> handle(HttpRequest request, Exception exception) {
-        ProblemDetail problemDetail = problemDetailMapper.map(exception);
+        String instance = request.getUri().getPath();
+        ProblemDetail problemDetail = problemDetailMapper.map(exception, instance);
 
         return HttpResponse
                 .<ProblemDetail>status(

--- a/response4j-quarkus/pom.xml
+++ b/response4j-quarkus/pom.xml
@@ -13,7 +13,7 @@
     <name>response4j-quarkus</name>
 
     <properties>
-        <quarkus.version>3.32.1</quarkus.version>
+        <quarkus.version>3.22.3</quarkus.version>
     </properties>
 
     <dependencyManagement>
@@ -36,7 +36,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/response4j-quarkus/src/main/java/io/github/iamkavindu/response4j/quarkus/mapper/Response4jExceptionMapper.java
+++ b/response4j-quarkus/src/main/java/io/github/iamkavindu/response4j/quarkus/mapper/Response4jExceptionMapper.java
@@ -4,22 +4,30 @@ import io.github.iamkavindu.response4j.mapper.ProblemDetailMapper;
 import io.github.iamkavindu.response4j.model.ProblemDetail;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
 /**
- * JAX-RS {@link ExceptionMapper} that produces RFC 7807 {@link ProblemDetail} responses
+ * JAX-RS {@link ExceptionMapper} that produces RFC 9457 {@link ProblemDetail} responses
  * for all exceptions.
  * <p>
  * Returns responses with {@code Content-Type: application/problem+json} and the appropriate
  * HTTP status from the mapped problem detail (or 500 for unmapped exceptions).
+ * <p>
+ * Per RFC 9457 Section 3.1, the {@code instance} field is populated with the request URI to help
+ * identify the specific occurrence of the problem.
  */
 @Provider
 @ApplicationScoped
 public class Response4jExceptionMapper implements ExceptionMapper<Exception> {
 
     private final ProblemDetailMapper problemDetailMapper;
+
+    @Context
+    private UriInfo uriInfo;
 
     /**
      * Creates the mapper with the given {@link ProblemDetailMapper}.
@@ -32,14 +40,18 @@ public class Response4jExceptionMapper implements ExceptionMapper<Exception> {
     }
 
     /**
-     * Maps the exception to a JAX-RS response containing the RFC 7807 problem detail.
+     * Maps the exception to a JAX-RS response containing the RFC 9457 problem detail.
+     * <p>
+     * The request URI is passed to the mapper to populate the {@code instance} field,
+     * which identifies the specific occurrence of the problem per RFC 9457.
      *
      * @param exception the thrown exception
      * @return a response with {@code Content-Type: application/problem+json} and the mapped status
      */
     @Override
     public Response toResponse(Exception exception) {
-        ProblemDetail problemDetail = problemDetailMapper.map(exception);
+        String instance = uriInfo != null ? uriInfo.getPath() : null;
+        ProblemDetail problemDetail = problemDetailMapper.map(exception, instance);
         return Response
                 .status(problemDetail.status())
                 .type("application/problem+json")

--- a/response4j-spring/src/main/java/io/github/iamkavindu/response4j/spring/handler/Response4jExceptionHandler.java
+++ b/response4j-spring/src/main/java/io/github/iamkavindu/response4j/spring/handler/Response4jExceptionHandler.java
@@ -2,16 +2,20 @@ package io.github.iamkavindu.response4j.spring.handler;
 
 import io.github.iamkavindu.response4j.mapper.ProblemDetailMapper;
 import io.github.iamkavindu.response4j.model.ProblemDetail;
+import org.springframework.http.HttpRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /**
- * Global exception handler that produces RFC 7807 {@link ProblemDetail} responses for all exceptions.
+ * Global exception handler that produces RFC 9457 {@link ProblemDetail} responses for all exceptions.
  * <p>
  * Returns responses with {@code Content-Type: application/problem+json} and the appropriate
  * HTTP status from the mapped problem detail (or 500 for unmapped exceptions).
+ * <p>
+ * Per RFC 9457 Section 3.1, the {@code instance} field is populated with the request URI to help
+ * identify the specific occurrence of the problem.
  */
 @RestControllerAdvice
 public class Response4jExceptionHandler {
@@ -29,13 +33,18 @@ public class Response4jExceptionHandler {
     /**
      * Handles all exceptions, mapping them to ProblemDetail and returning as
      * {@code application/problem+json}.
+     * <p>
+     * The request URI is passed to the mapper to populate the {@code instance} field,
+     * which identifies the specific occurrence of the problem per RFC 9457.
      *
+     * @param request   the HTTP request that triggered the exception
      * @param exception the thrown exception
      * @return a response entity with the mapped ProblemDetail and appropriate status
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ProblemDetail> handleException(Exception exception) {
-        ProblemDetail problemDetail = problemDetailMapper.map(exception);
+    public ResponseEntity<ProblemDetail> handleException(HttpRequest request, Exception exception) {
+        String instance = request.getURI().toString();
+        ProblemDetail problemDetail = problemDetailMapper.map(exception, instance);
         return ResponseEntity
                 .status(problemDetail.status())
                 .contentType(MediaType.APPLICATION_PROBLEM_JSON)


### PR DESCRIPTION
- Updated `ProblemDetail` to align with RFC 9457, updating references, doc comments, and methods.
- Added `ProblemDetail.ofErrors` for handling multiple sub-errors in validation scenarios.
- Enhanced `ProblemDetailMapper` to populate the `instance` field with the request URI.
- Introduced comprehensive test coverage for `ProblemDetail`, `ProblemDetailError`, `ProblemDetailMapper`, and related utilities.
- Adjusted `Response4jExceptionMapper` to make use of the updated `instance` field.